### PR TITLE
Fix NULL entity error

### DIFF
--- a/lua/autorun/server/sit.lua
+++ b/lua/autorun/server/sit.lua
@@ -456,6 +456,7 @@ local function UndoSitting(self, ply)
 	if(self.exit) then
 		self.exit(ply)
 	end
+    if not IsValid( self ) then return end
 	self:Remove()
 end
 

--- a/lua/autorun/server/sit.lua
+++ b/lua/autorun/server/sit.lua
@@ -456,7 +456,7 @@ local function UndoSitting(self, ply)
 	if(self.exit) then
 		self.exit(ply)
 	end
-    if not IsValid( self ) then return end
+	if not IsValid( self ) then return end
 	self:Remove()
 end
 


### PR DESCRIPTION
stack:
```
addons/sit_anywhere/lua/autorun/server/sit.lua:459: Tried to use a NULL entity!
   0.  unkown - [C]:-1
    1.  Remove - [C]:-1
     2.  UndoSitting - addons/sit_anywhere/lua/autorun/server/sit.lua:459
      3.  callback - addons/sit_anywhere/lua/autorun/server/sit.lua:539
       4.  UnStuck - addons/sit_anywhere/lua/autorun/server/unstuck.lua:41
        5.  fn - addons/sit_anywhere/lua/autorun/server/unstuck.lua:75
         6.  unkown - addons/ulib/lua/ulib/shared/hook.lua:109
```